### PR TITLE
Ensure Secretbuddy `.profile.d` script is executed first

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -46,7 +46,7 @@ ls -la $BUILDPACK_DIR
 ls -la $BUILDPACK
 mkdir -p "$BUILD_DIR/.profile.d"
 
-cp $BUILDPACK_DIR/profile/secret-buddy.sh $BUILD_DIR/.profile.d/secret-buddy.sh
+cp $BUILDPACK_DIR/profile/secret-buddy.sh $BUILD_DIR/.profile.d/0000-secret-buddy.sh
 
 echo "Copying buildpack exec to $BUILD_DIR/.profile.d/secret-buddy-buildpack"
 cp $BUILDPACK $BUILD_DIR/.profile.d/secret-buddy-buildpack 


### PR DESCRIPTION
The order of execution of `.profile.d` scripts is alphabetical. I believe we need this to execute before the `.profile.d/ruby.sh` script sets SECRET_KEY_BASE which is generated by the heroku/ruby buildpack https://github.com/heroku/heroku-buildpack-ruby/blob/8559194e2606d05160ad0a117e30207733733309/lib/language_pack/base.rb#L211. 

Therefore we can fix the order by changing the name of the secret buddy script to a 0. It's inelegant but robust.

[close #29]