### PR TITLE
Add secrets info - fix for apps with no /bin directory

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -37,7 +37,6 @@ if [ -z "$SECRETBUDDY" ]; then
 fi
 
 BUILDPACK=$BUILDPACK_DIR/secret-buddy-buildpack
-CHECK_SECRETBUDDY_ENVS_SCRIPT=$BUILDPACK_DIR/check-secretbuddy
 
 # uncomment for debugging
 #ls -la $BUILDPACK_DIR
@@ -49,9 +48,6 @@ cp $BUILDPACK_DIR/profile/secret-buddy.sh $BUILD_DIR/.profile.d/0000-secret-budd
 echo "Copying buildpack exec to $BUILD_DIR/.profile.d/secret-buddy-buildpack"
 cp $BUILDPACK $BUILD_DIR/.profile.d/secret-buddy-buildpack
 
-echo "Copying check-secretbuddy to $BUILD_DIR/bin/check-secretbuddy"
-cp $CHECK_SECRETBUDDY_ENVS_SCRIPT $BUILD_DIR/bin/check-secretbuddy
-chmod 755 $BUILD_DIR/bin/check-secretbuddy
 #ls -la $BUILD_DIR/bin
 
 #echo "BUILD_DIR: $BUILD_DIR"

--- a/bin/compile
+++ b/bin/compile
@@ -37,6 +37,8 @@ if [ -z "$SECRETBUDDY" ]; then
 fi
 
 BUILDPACK=$BUILDPACK_DIR/secret-buddy-buildpack
+CHECK_SECRETBUDDY_ENVS_SCRIPT=$BUILDPACK_DIR/check-secretbuddy
+TARGET_BIN_DIR=$BUILD_DIR/bin
 
 # uncomment for debugging
 #ls -la $BUILDPACK_DIR
@@ -47,6 +49,17 @@ cp $BUILDPACK_DIR/profile/secret-buddy.sh $BUILD_DIR/.profile.d/0000-secret-budd
 
 echo "Copying buildpack exec to $BUILD_DIR/.profile.d/secret-buddy-buildpack"
 cp $BUILDPACK $BUILD_DIR/.profile.d/secret-buddy-buildpack
+
+# Now, for copying the check-secretbuddy script, first check if the /bin directory exists
+# If it doesn't, create it
+if [ ! -d "$TARGET_BIN_DIR" ]; then
+    mkdir "$TARGET_BIN_DIR"
+fi
+
+# Copy the check-secretbuddy script to the /bin directory
+echo "Copying check-secretbuddy to $TARGET_BIN_DIR/check-secretbuddy"
+cp $CHECK_SECRETBUDDY_ENVS_SCRIPT $TARGET_BIN_DIR/check-secretbuddy
+chmod 755 $TARGET_BIN_DIR/check-secretbuddy
 
 #ls -la $BUILD_DIR/bin
 

--- a/check-secretbuddy
+++ b/check-secretbuddy
@@ -58,17 +58,14 @@ print("#3 - (secret) Config vars that do not exist in Secretbuddy vars: ", end="
 pattern = re.compile(r'(?i).*(secret|token|key|pass|auth|cred|certificate|cert|bearer|sign|salt).*')
 found = False
 for key, value in os.environ.items():
-    #print("JLD: ", key)
     if key == secretbuddy_env_var:
       continue
     if pattern.match(key):
-      #print("JLD matcheo")
-      #print(secretbuddy_data_json["current"])
       if key not in secretbuddy_data_json["current"]:
         if not found:
           print(end="\n")
           found = True
-        print(f"{CYAN}\t{key}: {value}{RESET}")
+        print(f"{CYAN}\t{key}: {anonim(value)}{RESET}")
 
 if not found:
   print(f"{CYAN}None{RESET}")

--- a/check-secretbuddy
+++ b/check-secretbuddy
@@ -8,6 +8,11 @@ CYAN = "\033[36m"
 RESET = "\033[0m"
 
 # --------------------------------------------------------------------------------------------------
+# function to anonimize the value by returning only the first 4 characters
+# followed by "..."
+def anonim(input_string):
+    return input_string[:4] + "..."
+# --------------------------------------------------------------------------------------------------
 # check if the environment variable SECRETBUDDY_ENV is set and not empty
 # and the JSON is valid
 secretbuddy_env_var = "SECRETBUDDY_ENV"
@@ -26,7 +31,7 @@ except json.JSONDecodeError as e:
 # print the list of Secretbuddy vars
 print("#1 - List of Secretbuddy vars: ")
 for k, v in secretbuddy_data_json["current"].items():
-    print(f"\t{CYAN}{k}{RESET}")
+    print(f"\t{CYAN}{k}:{anonim(v)}{RESET}")
 
 # --------------------------------------------------------------------------------------------------
 # check if the environment variables match the Secretbuddy vars
@@ -37,12 +42,12 @@ for k, v in secretbuddy_data_json["current"].items():
     env_value = os.getenv(k)
     if env_value is None:
       continue
-    if v != env_value:
+    # strip newlines from the values before comparing
+    if v.replace('\n', '') != env_value.replace('\n', ''):
       if not found:
         print(end="\n")
         found = True
-      #print(f"\t{CYAN}{k}, value:{env_value} secretbuddy:{v}{RESET}")
-      print(f"\t{CYAN}{k}{RESET}")
+      print(f"\t{CYAN}{k}{RESET}<==>value:{CYAN}{anonim(env_value)}{RESET} secretbuddy:{CYAN}{anonim(v)}{RESET}")
 
 if not found:
   print(f"{CYAN}None{RESET}")


### PR DESCRIPTION
There are projects (like central-odcr-prod) which dont have a /bin folder after their deployment
And this bin folder is the one we chose for storing the script

So now, it is created

https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE000020fGePYAU/view