### PR TITLE
W 17328912 fix buildpack first

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -33,7 +33,7 @@ echo "       WARNING: Secretbuddy does not support using secrets during build ti
 export_env_dir $ENV_DIR
 SECRETBUDDY="$SECRETBUDDY_ENV"
 if [ -z "$SECRETBUDDY" ]; then
-  echo "       Warning: SECRETBUDDY_ENV not found. This may be due to a missing addon or consolidation rules."
+  echo "       WARNING: SECRETBUDDY_ENV not found. This may be due to a missing addon or consolidation rules."
 fi
 
 BUILDPACK=$BUILDPACK_DIR/secret-buddy-buildpack

--- a/bin/compile
+++ b/bin/compile
@@ -28,12 +28,12 @@ export_env_dir() {
   fi
 }
 
+echo "       WARNING: Secretbuddy does not support using secrets during build time."
 
 export_env_dir $ENV_DIR
 SECRETBUDDY="$SECRETBUDDY_ENV"
 if [ -z "$SECRETBUDDY" ]; then
-  echo "No secrets found"
-  exit 0
+  echo "       Warning: SECRETBUDDY_ENV not found. This may be due to a missing addon or consolidation rules."
 fi
 
 BUILDPACK=$BUILDPACK_DIR/secret-buddy-buildpack
@@ -47,7 +47,7 @@ mkdir -p "$BUILD_DIR/.profile.d"
 
 cp $BUILDPACK_DIR/profile/secret-buddy.sh $BUILD_DIR/.profile.d/0000-secret-buddy.sh
 
-echo "Copying buildpack exec to $BUILD_DIR/.profile.d/secret-buddy-buildpack"
+echo "       Copying buildpack exec to $BUILD_DIR/.profile.d/secret-buddy-buildpack"
 cp $BUILDPACK $BUILD_DIR/.profile.d/secret-buddy-buildpack
 
 # Now, for copying the check-secretbuddy script, first check if the /bin directory exists
@@ -57,10 +57,11 @@ if [ ! -d "$TARGET_BIN_DIR" ]; then
 fi
 
 # Copy the check-secretbuddy script to the /bin directory
-echo "Copying check-secretbuddy to $TARGET_BIN_DIR/check-secretbuddy"
+echo "       Copying check-secretbuddy to $TARGET_BIN_DIR/check-secretbuddy"
 cp $CHECK_SECRETBUDDY_ENVS_SCRIPT $TARGET_BIN_DIR/check-secretbuddy
 chmod 755 $TARGET_BIN_DIR/check-secretbuddy
 
+# ALL of these commented-out commands are left for debugging purposes
 #ls -la $BUILD_DIR/bin
 
 #echo "BUILD_DIR: $BUILD_DIR"


### PR DESCRIPTION
This PR improves 3 (three) usability improvements:

1 - adds a Warning message informing that secretbuddy does not support secrets during buildtime. It will help debugging for teams that are adding apps with those secrets
2 - Now, during `compile` if the SECRETBUDDY_ENV is not found, it will not exit, so the slug will be created with the buildpack. Then if afterward the situation is fixed, a new release of the application will not be needed.
Also a Warning message is printed out to inform of this situation.
3 - blank spaces were added in the printed out messages, so it is compliant with buildpack logs,
